### PR TITLE
Relax attrs requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='0.5.5.dev1',
+    version='0.5.5.dev2',
     description='Library for building Grafana dashboards',
     long_description=open(README).read(),
     url='https://github.com/weaveworks/grafanalib',
@@ -38,7 +38,7 @@ setup(
         'Topic :: System :: Monitoring',
     ],
     install_requires=[
-        'attrs==19.2',
+        'attrs>=19.2',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Broken attrs change happened in 19.2 but strict requirement is not necessary.